### PR TITLE
Added Usebasicparsing Flag

### DIFF
--- a/CommvaultPowerShell/custom/oldsdk/ProcessRequest.ps1
+++ b/CommvaultPowerShell/custom/oldsdk/ProcessRequest.ps1
@@ -30,11 +30,11 @@ function ProcessRequest () {
             Write-Debug $url
             Write-Debug $method
             Write-Debug $body
-            $response = Invoke-WebRequest -Uri $url -Method $Method -Body $Body -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck
+            $response = Invoke-WebRequest -Uri $url -Method $Method -Body $Body -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck -UseBasicParsing
             Write-Debug $response
         }
         elseif ($Method.ToLower() -eq 'get') {
-            $response = Invoke-WebRequest -Uri $url -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck
+            $response = Invoke-WebRequest -Uri $url -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck -UseBasicParsing
         }
     
         $output['Status'] = $response.StatusCode

--- a/CommvaultPowerShell/custom/oldsdk/ProcessRequest.ps1
+++ b/CommvaultPowerShell/custom/oldsdk/ProcessRequest.ps1
@@ -6,6 +6,7 @@ $CVPS_ERROR_ID = @{
     1001 = 'Empty or null secure password: Please provide secure password for web service login'
     1002 = 'Invalid CommServe session token: Please login to CommServe with Invoke-SetupLogin'
 }
+
 function ProcessRequest () {
     
     param (
@@ -30,11 +31,21 @@ function ProcessRequest () {
             Write-Debug $url
             Write-Debug $method
             Write-Debug $body
-            $response = Invoke-WebRequest -Uri $url -Method $Method -Body $Body -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck -UseBasicParsing
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                $response = Invoke-WebRequest -Uri $url -Method $Method -Body $Body -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck
+            }
+            else {
+                $response = Invoke-WebRequest -Uri $url -Method $Method -Body $Body -Headers $Header -ContentType $ContentType -ErrorAction Stop -UseBasicParsing
+            }
             Write-Debug $response
         }
         elseif ($Method.ToLower() -eq 'get') {
-            $response = Invoke-WebRequest -Uri $url -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck -UseBasicParsing
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                $response = Invoke-WebRequest -Uri $url -Headers $Header -ContentType $ContentType -ErrorAction Stop -SkipCertificateCheck
+            }
+            else {
+                $response = Invoke-WebRequest -Uri $url -Headers $Header -ContentType $ContentType -ErrorAction Stop -UseBasicParsing
+            }
         }
     
         $output['Status'] = $response.StatusCode


### PR DESCRIPTION
When executed in PowerShell 5.1, Invoke-WebRequest may rely on legacy parsing components, leading to interactive prompts or execution hang in background/scheduled runs